### PR TITLE
Noting that na_if() is depreceated

### DIFF
--- a/09-supervised_ml_I.Rmd
+++ b/09-supervised_ml_I.Rmd
@@ -205,7 +205,8 @@ daily_fluxes <- read_csv("./data/FLX_CH-Dav_FLUXNET2015_FULLSET_DD_1997-2014_1-3
   dplyr::mutate(TIMESTAMP = ymd(TIMESTAMP)) |>
 
   # set all -9999 to NA
-  dplyr::na_if(-9999) |>
+  dplyr::na_if(-9999) |> # NOTE: Newer tidyverse version no longer support this statement
+                         # instead, use `mutate(across(where(is.numeric), ~na_if(., -9999))) |> `
   
   # retain only data based on >=80% good-quality measurements
   # overwrite bad data with NA (not dropping rows)

--- a/10-supervised_ml_II.Rmd
+++ b/10-supervised_ml_II.Rmd
@@ -29,7 +29,8 @@ daily_fluxes <- readr::read_csv("./data/FLX_CH-Dav_FLUXNET2015_FULLSET_DD_1997-2
   dplyr::mutate(TIMESTAMP = ymd(TIMESTAMP)) |>
 
   # set all -9999 to NA
-  dplyr::na_if(-9999) |>
+  dplyr::na_if(-9999) |> # NOTE: Newer tidyverse version no longer support this statement
+                         # instead, use `mutate(across(where(is.numeric), ~na_if(., -9999))) |> ` 
   
   # retain only data based on >=80% good-quality measurements
   # overwrite bad data with NA (not dropping rows)

--- a/11-randomforest.Rmd
+++ b/11-randomforest.Rmd
@@ -170,8 +170,10 @@ daily_fluxes <- daily_fluxes |>
   
   # convert to a nice date object
   dplyr::mutate(TIMESTAMP = ymd(TIMESTAMP)) |>
+  
   # set all -9999 to NA
-  dplyr::na_if(-9999) |>
+  dplyr::na_if(-9999) |> # NOTE: Newer tidyverse version no longer support this statement
+                         # instead, use `mutate(across(where(is.numeric), ~na_if(., -9999))) |> ` 
   
   # retain only data based on >=80% good-quality measurements
   # overwrite bad data with NA (not dropping rows)

--- a/12-appendix.Rmd
+++ b/12-appendix.Rmd
@@ -433,8 +433,9 @@ In Section \@ref(baddata), we discovered that certain values of `GPP_NT_VUT_REF`
 # Read and wrangle data
 half_hourly_fluxes <- readr::read_csv("data/FLX_CH-Lae_FLUXNET2015_FULLSET_HH_2004-2006.csv") |> 
   
-    # interpret -9999 as missing value
-    dplyr::na_if(-9999) |> 
+    # set all -9999 to NA
+    dplyr::na_if(-9999) |> # NOTE: Newer tidyverse version no longer support this statement
+                           # instead, use `mutate(across(where(is.numeric), ~na_if(., -9999))) |> ` 
   
     # interpret all variables starting with TIMESTAMP as a date-time object
     dplyr::mutate_at(vars(starts_with("TIMESTAMP_")), lubridate::ymd_hm)
@@ -625,6 +626,9 @@ ml_co2 <- ml_co2 |>
   dplyr::na_if(-0.99) |> 
   dplyr::na_if(-1) |>
   rename(year_dec = `decimal date`)
+
+# NOTE: Newer tidyverse version no longer support statements like `dplyr::na_if(-9.99)`
+# instead, use `mutate(across(where(is.numeric), ~na_if(., -9.99))) |> ` 
 ```
 
 -   Make a simple graph for visualizing the monthly CO$_2$ time series.

--- a/data-raw/prepare_flux_data.R
+++ b/data-raw/prepare_flux_data.R
@@ -27,7 +27,8 @@ daily_fluxes <- readr::read_csv("./data/FLX_CH-Dav_FLUXNET2015_FULLSET_DD_1997-2
   dplyr::mutate(TIMESTAMP = ymd(TIMESTAMP)) |>
   
   # set all -9999 to NA
-  dplyr::na_if(-9999) |>
+  dplyr::na_if(-9999) |> # NOTE: Newer tidyverse version no longer support this statement
+                         # instead, use `mutate(across(where(is.numeric), ~na_if(., -9999))) |> ` 
   
   # retain only data based on >=80% good-quality measurements
   # overwrite bad data with NA (not dropping rows)

--- a/save/solutions.Rmd
+++ b/save/solutions.Rmd
@@ -323,8 +323,9 @@ library(lubridate)  # not part of the automatic load of tidyverse
 # read half-hourly data
 hhdf <- read_csv("data/FLX_CH-Lae_FLUXNET2015_FULLSET_HH_2004-2006.csv") |> 
   
-    # interpret -9999 as missing value
-    na_if(-9999) |> 
+      # set all -9999 to NA
+      dplyr::na_if(-9999) |> # NOTE: Newer tidyverse version no longer support this statement
+                             # instead, use `mutate(across(where(is.numeric), ~na_if(., -9999))) |> `  
   
     # interpret timestamp as a date-time object
     mutate_at(vars(starts_with("TIMESTAMP_")), ymd_hm)


### PR DESCRIPTION
I added comments where necessary to indicate that `na_if()` no longer works in newer tidyverse versions. `mutate(across(where(is.numeric), ~na_if(., -9999)))` should be used instead.

This should probably be cleaner and using the mutate-across... code directly. But I left it in for now to avoid confusion.